### PR TITLE
feat: focus Tiny-Priest MVP on priest 3D flow

### DIFF
--- a/Project/TINY-PRIEST/script.js
+++ b/Project/TINY-PRIEST/script.js
@@ -2,6 +2,22 @@
     priest: {
         frontImage: "assets/priest_front.png",
         backImage: "assets/priest_back.png",
+        frontImageCandidates: [
+            "assets/characters/priest/priest_front.png",
+            "assets/characters/priest/front.png",
+            "assets/characters/priest/priest_front.webp",
+            "assets/characters/priest/front.webp",
+            "assets/characters/priest/priest_front.jpg",
+            "assets/characters/priest/front.jpg",
+        ],
+        backImageCandidates: [
+            "assets/characters/priest/priest_back.png",
+            "assets/characters/priest/back.png",
+            "assets/characters/priest/priest_back.webp",
+            "assets/characters/priest/back.webp",
+            "assets/characters/priest/priest_back.jpg",
+            "assets/characters/priest/back.jpg",
+        ],
         welcomeText: "Father: Peace be with you! Let's walk through the center door.",
     },
     nun: {
@@ -20,6 +36,8 @@ const APP_STATE = {
     hudBound: false,
     massNavBound: false,
 };
+
+const ASSET_PROBE_CACHE = new Map();
 
 const THREE_CDN_FALLBACKS = [
     "vendor/three.min.js",
@@ -211,6 +229,63 @@ const MASS_FLOW_STEPS = [
 function resolvePlayableCharacter(character) {
     // MVP scope: the 3D playable role is fixed to priest.
     return character === "priest" ? "priest" : "priest";
+}
+
+function probeImageExists(url) {
+    if (!url) {
+        return Promise.resolve(false);
+    }
+    if (ASSET_PROBE_CACHE.has(url)) {
+        return ASSET_PROBE_CACHE.get(url);
+    }
+
+    const probePromise = new Promise((resolve) => {
+        const image = new Image();
+        image.onload = () => resolve(true);
+        image.onerror = () => resolve(false);
+        image.src = url;
+    });
+    ASSET_PROBE_CACHE.set(url, probePromise);
+    return probePromise;
+}
+
+async function resolveAssetFromCandidates(candidates, fallbackUrl) {
+    for (const url of candidates || []) {
+        // Prefer the newly organized assets folder when available.
+        if (await probeImageExists(url)) {
+            return url;
+        }
+    }
+    return fallbackUrl;
+}
+
+async function ensureCharacterAssetsResolved(character) {
+    const config = CHARACTER_CONFIG[character];
+    if (!config || config.assetsResolved) {
+        return;
+    }
+
+    config.frontImage = await resolveAssetFromCandidates(config.frontImageCandidates, config.frontImage);
+    config.backImage = await resolveAssetFromCandidates(config.backImageCandidates, config.backImage);
+    config.assetsResolved = true;
+}
+
+function syncEntryCharacterImage(character) {
+    const config = CHARACTER_CONFIG[character];
+    const characterEl = getCharacterElement(character);
+    const imageEl = characterEl?.querySelector("img");
+    if (config?.frontImage && imageEl) {
+        imageEl.src = config.frontImage;
+    }
+}
+
+async function initializeCharacterAssets() {
+    await Promise.all(
+        Object.keys(CHARACTER_CONFIG).map(async (character) => {
+            await ensureCharacterAssetsResolved(character);
+            syncEntryCharacterImage(character);
+        }),
+    );
 }
 
 function buildMassFlowNavigation() {
@@ -1866,6 +1941,10 @@ async function handleInteract(character) {
     APP_STATE.isTransitioning = true;
     APP_STATE.selectedCharacter = character;
     APP_STATE.playableCharacter = resolvePlayableCharacter(character);
+    await ensureCharacterAssetsResolved(character);
+    await ensureCharacterAssetsResolved(APP_STATE.playableCharacter);
+    syncEntryCharacterImage(character);
+    syncEntryCharacterImage(APP_STATE.playableCharacter);
 
     const characterEl = getCharacterElement(character);
     if (!characterEl) {
@@ -1888,3 +1967,4 @@ async function handleInteract(character) {
 
 window.handleInteract = handleInteract;
 window.getLiturgicalSeason = getLiturgicalSeason;
+initializeCharacterAssets();

--- a/Project/TINY-PRIEST/script.js
+++ b/Project/TINY-PRIEST/script.js
@@ -14,6 +14,7 @@
 const APP_STATE = {
     isTransitioning: false,
     selectedCharacter: null,
+    playableCharacter: "priest",
     threeWorld: null,
     threeLoadPromise: null,
     hudBound: false,
@@ -206,6 +207,11 @@ const MASS_FLOW_STEPS = [
         text: "🔔 The people are blessed and sent forth to live the Gospel.",
     },
 ];
+
+function resolvePlayableCharacter(character) {
+    // MVP scope: the 3D playable role is fixed to priest.
+    return character === "priest" ? "priest" : "priest";
+}
 
 function buildMassFlowNavigation() {
     const groupsContainer = document.getElementById("mass-nav-groups");
@@ -859,8 +865,9 @@ function createVoxelChurch(container) {
         }
     }
 
-    const selected = CHARACTER_CONFIG[APP_STATE.selectedCharacter] || CHARACTER_CONFIG.nun;
-    const isPriest = APP_STATE.selectedCharacter === "priest";
+    const activeRole = APP_STATE.playableCharacter || "priest";
+    const selected = CHARACTER_CONFIG[activeRole] || CHARACTER_CONFIG.priest;
+    const isPriest = activeRole === "priest";
 
     const playerRig = new THREE.Group();
     playerRig.position.set(0, 0, 10.8);
@@ -1858,6 +1865,7 @@ async function handleInteract(character) {
 
     APP_STATE.isTransitioning = true;
     APP_STATE.selectedCharacter = character;
+    APP_STATE.playableCharacter = resolvePlayableCharacter(character);
 
     const characterEl = getCharacterElement(character);
     if (!characterEl) {
@@ -1867,11 +1875,15 @@ async function handleInteract(character) {
 
     lockCharacterSelection();
     switchToBackSprite(character, characterEl);
-    setDialogue(CHARACTER_CONFIG[character].welcomeText);
+    const isRoleDeferred = APP_STATE.playableCharacter !== character;
+    const entryMessage = isRoleDeferred
+        ? `${CHARACTER_CONFIG[character].welcomeText} Sister 3D mode will be added next, so we'll continue with Father Priest for now.`
+        : CHARACTER_CONFIG[character].welcomeText;
+    setDialogue(entryMessage);
 
     await animateCharacterEntry(characterEl);
     await animateDoorZoomTransition();
-    await activateThreeScene(character);
+    await activateThreeScene(APP_STATE.playableCharacter);
 }
 
 window.handleInteract = handleInteract;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep initial character selection screen unchanged
- scope 3D playable role to priest for faster MVP completion
- when nun is selected, keep entry animation and show guidance that nun 3D mode will be added later
- wire priest visuals to prefer files under `assets/characters/priest` with fallback to legacy paths

## Details
- added `playableCharacter` in app state
- added `resolvePlayableCharacter()` to enforce priest-only 3D role for MVP
- updated 3D character setup to use resolved playable role
- updated interaction dialogue and scene activation path for deferred nun support
- added candidate-based priest asset resolution (`assets/characters/priest/*` first)
- added startup + interaction-time asset syncing for entry-screen character image
- retained safe fallback to existing `assets/priest_front.png` and `assets/priest_back.png`

## Why
This aligns MVP delivery with the narrowed scope:
- initial screen with selectable characters remains
- core 3D movement, 7 gestures, and mass auto/manual navigation stay intact
- nun playable 3D behavior is postponed to a follow-up iteration
- priest asset folder can be adopted without breaking environments that still use legacy file locations

## Validation
- `node --check Project/TINY-PRIEST/script.js` passed
- verified branch updates pushed successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc87aca4-9bfb-4dd1-a7ee-3f8356bf137b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc87aca4-9bfb-4dd1-a7ee-3f8356bf137b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

